### PR TITLE
ODY-441 カードが回転することがわかるようにする

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "postcss": "8.4.27",
         "react": "18.2.0",
         "react-dom": "18.2.0",
+        "react-icons": "^5.0.1",
         "tailwind-merge": "^1.14.0",
         "tailwindcss": "3.3.3",
         "typescript": "5.1.6"
@@ -16579,6 +16580,14 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.1.0.tgz",
       "integrity": "sha512-Fl7FuabXsJnV5Q1qIOQwx/sagGF18kogb4gpfcG4gjLBWO0WDiiz1ko/ExayuxE7InyQkBLkxRFG5oxY6Uu3Kg==",
       "dev": true
+    },
+    "node_modules/react-icons": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/react-icons/-/react-icons-5.0.1.tgz",
+      "integrity": "sha512-WqLZJ4bLzlhmsvme6iFdgO8gfZP17rfjYEJ2m9RsZjZ+cc4k1hTzknEz63YS1MeT50kVzoa1Nz36f4BEx+Wigw==",
+      "peerDependencies": {
+        "react": "*"
+      }
     },
     "node_modules/react-inspector": {
       "version": "6.0.2",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "postcss": "8.4.27",
     "react": "18.2.0",
     "react-dom": "18.2.0",
+    "react-icons": "^5.0.1",
     "tailwind-merge": "^1.14.0",
     "tailwindcss": "3.3.3",
     "typescript": "5.1.6"

--- a/src/components/tree/MainCard.tsx
+++ b/src/components/tree/MainCard.tsx
@@ -1,4 +1,5 @@
 import { ReactNode } from 'react';
+import { BsPhoneFlip } from 'react-icons/bs';
 import { twMerge } from 'tailwind-merge';
 
 type Props = {
@@ -24,6 +25,7 @@ const MainCard = ({ children, title, headerBgColor, rotateCard }: Props) => {
         <svg xmlns='http://www.w3.org/2000/svg' width='12' height='13' viewBox='0 0 12 13' fill='none'>
           <circle cx='6' cy='6.29102' r='6' fill='white' />
         </svg>
+        <BsPhoneFlip className='absolute right-8' />
       </section>
       <section className='flex h-[535px] w-full items-center justify-center p-[30px]' data-testid='MainCard_Children'>
         {children}

--- a/src/components/tree/MainCardWithCommodityResult.tsx
+++ b/src/components/tree/MainCardWithCommodityResult.tsx
@@ -23,7 +23,7 @@ const MainCardWithCommodityResult = ({ commodities, rotateCard }: Props) => {
   }, [commodities]);
 
   return (
-    <MainCard title='購入可能商品' headerBgColor='bg-yellow-200' rotateCard={rotateCard}>
+    <MainCard title='Result' headerBgColor='bg-yellow-200' rotateCard={rotateCard}>
       {commodities.length === 0 && (
         <div>
           <p>ここには購入可能な商品が表示されます。</p>

--- a/src/components/tree/MainCardWithMoneyResult.tsx
+++ b/src/components/tree/MainCardWithMoneyResult.tsx
@@ -29,7 +29,7 @@ const MainCardWithMoneyResult = ({ rotateCard }: MainCardWithMoneyResultProps) =
   }, [mainPrice]);
 
   return (
-    <MainCard title='得した金額/損した金額' headerBgColor='bg-cyan-400' rotateCard={rotateCard}>
+    <MainCard title='Result' headerBgColor='bg-cyan-400' rotateCard={rotateCard}>
       <div className='flex h-[124px] flex-col items-end justify-between'>
         <p className='text-4xl'>¥ {mainPrice.toLocaleString()}</p>
         <p className='text-base'>前回：¥ {previousPrice !== null ? previousPrice.toLocaleString() : '---'}</p>


### PR DESCRIPTION
# 事前確認(共通)

- [x] PR 前に動作確認をしたか
- [x] ビルドエラー/ESLint エラーは起きていないか
- [x] [開発ルール](https://daydule.atlassian.net/wiki/spaces/DAYDULE/pages/9765029)を守って実装しているか
- [ ] 単体テストが全て OK になっているか（現状はフロントエンドの単体テストを実行できていないため）
- [x] 機密情報を含んでいないか
- [x] 最新の`develop`ブランチを反映しているか

# レビュー優先度（どれか一つ）

- [ ] すぐ見てもらいたい
- [x] 3 日くらいで見てもらいたい
- [ ] 7 日くらいで見てもらいたい

# レビューの度合い

- [x] コードをぱっと確認してもらいたい
- [ ] コードをぱっと確認 & 動作確認してもらいたい
- [ ] コードをしっかり確認 & 動作確認してもらいたい

# レビュワーによる動作確認

- [ ] @atoook 
- [ ] @Mellbrother 
- [ ] @kzk27 

# やったこと<!-- このプルリクエストでやったことを書く -->

- カードが回転することがわかるようなアイコン追加
- （ついで）右のカードのタイトルを一般的なものに変更

# やらないこと<!-- このプルリクエストでやってもおかしくないけどやらなかったことを書く -->

特になし

# 懸念点や注意点<!-- このプルリクエストにおける懸念点や注意点を書く -->

特になし

# その他<!-- このプルリクエストで上記の項目以外に伝えるべきことを書く -->

アイコンのスクショ↓

<img width="388" alt="アイコンの画像" src="https://github.com/daydule/odyssey-frontend/assets/57748294/739bf1e6-8d7b-4915-b0b5-acfc583d2393">


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **新機能**
	- `MainCard`コンポーネントに電話アイコン(`BsPhoneFlip`)を追加しました。
- **改善点**
	- `MainCardWithCommodityResult`コンポーネントのタイトルを日本語の「購入可能商品」から英語の「Result」に変更しました。
	- `MainCardWithMoneyResult`コンポーネントのタイトルを日本語の「得した金額/損した金額」から英語の「Result」に変更しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->